### PR TITLE
Added value to TransactionReceipt

### DIFF
--- a/src/main/java/org/adridadou/ethereum/propeller/values/TransactionReceipt.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/values/TransactionReceipt.java
@@ -16,8 +16,9 @@ public class TransactionReceipt {
     public final EthData executionResult;
     public final boolean isSuccessful;
     public final List<EventData> events;
+    public final EthValue ethValue;
 
-    public TransactionReceipt(EthHash hash, EthHash blockHash, EthAddress sender, EthAddress receiveAddress, EthAddress contractAddress, String error, EthData executionResult, boolean isSuccessful, List<EventData> events) {
+    public TransactionReceipt(EthHash hash, EthHash blockHash, EthAddress sender, EthAddress receiveAddress, EthAddress contractAddress, String error, EthData executionResult, boolean isSuccessful, List<EventData> events, EthValue ethValue) {
         this.hash = hash;
         this.blockHash = blockHash;
         this.sender = sender;
@@ -27,5 +28,6 @@ public class TransactionReceipt {
         this.executionResult = executionResult;
         this.isSuccessful = isSuccessful;
         this.events = events;
+        this.ethValue = ethValue;
     }
 }

--- a/src/test/java/org/adridadou/ethereum/propeller/backend/EthJEventListener.java
+++ b/src/test/java/org/adridadou/ethereum/propeller/backend/EthJEventListener.java
@@ -10,6 +10,7 @@ import org.ethereum.listener.EthereumListenerAdapter;
 import org.ethereum.vm.DataWord;
 import org.ethereum.vm.LogInfo;
 
+import java.math.BigInteger;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -39,6 +40,7 @@ public class EthJEventListener extends EthereumListenerAdapter {
 
     static org.adridadou.ethereum.propeller.values.TransactionReceipt toReceipt(TransactionReceipt transactionReceipt, EthHash blockHash) {
         Transaction tx = transactionReceipt.getTransaction();
+        EthValue value = tx.getValue().length == 0 ? EthValue.wei(0) : EthValue.wei(new BigInteger(1, tx.getValue()));
         return new org.adridadou.ethereum.propeller.values.TransactionReceipt(
                 EthHash.of(tx.getHash()),
                 blockHash,
@@ -47,7 +49,7 @@ public class EthJEventListener extends EthereumListenerAdapter {
                 EthAddress.of(tx.getContractAddress()),
                 transactionReceipt.getError(),
                 EthData.of(transactionReceipt.getExecutionResult()),
-                transactionReceipt.isSuccessful() && transactionReceipt.isValid(), createEventInfoList(EthHash.of(tx.getHash()), transactionReceipt.getLogInfoList()));
+                transactionReceipt.isSuccessful() && transactionReceipt.isValid(), createEventInfoList(EthHash.of(tx.getHash()), transactionReceipt.getLogInfoList()), value);
     }
 
     @Override

--- a/src/test/java/org/adridadou/ethereum/propeller/backend/EthereumTest.java
+++ b/src/test/java/org/adridadou/ethereum/propeller/backend/EthereumTest.java
@@ -146,7 +146,7 @@ public class EthereumTest implements EthereumBackend {
     }
 
     private TransactionReceipt toReceipt(Transaction tx, EthHash blockHash) {
-
+        EthValue value = tx.getValue().length == 0 ? EthValue.wei(0) : EthValue.wei(new BigInteger(1, tx.getValue()));
         List<LogInfo> logs = blockchain.getBlockchain().getTransactionInfo(tx.getHash()).getReceipt().getLogInfoList();
         return new TransactionReceipt(
                 EthHash.of(tx.getHash()),
@@ -156,6 +156,6 @@ public class EthereumTest implements EthereumBackend {
                 EthAddress.empty(), "",
                 EthData.empty(),
                 true,
-                EthJEventListener.createEventInfoList(EthHash.of(tx.getHash()), logs));
+                EthJEventListener.createEventInfoList(EthHash.of(tx.getHash()), logs), value);
     }
 }


### PR DESCRIPTION
Adding the value to the TransactionReceipt class. Since this is part of a receipt, users could need it when for example constructing a transaction overview page. Not only addresses are needed, but also the value being sent within the tx. Please leave feedback if there is anything wrong.