### PR TITLE
Fix the block polling for Infura

### DIFF
--- a/src/main/java/org/adridadou/ethereum/propeller/rpc/Web3JFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/rpc/Web3JFacade.java
@@ -77,9 +77,10 @@ public class Web3JFacade {
         Executors.newCachedThreadPool().submit(() -> {
             while (true) {
                 try {
-                    BigInteger currentBlockNumber = web3j.ethBlockNumber().send().getBlockNumber();
-                    while (this.lastBlockNumber.equals(BigInteger.ZERO) || currentBlockNumber.compareTo(this.lastBlockNumber) > 0) {
-                        EthBlock currentBlock = web3j.ethGetBlockByNumber(DefaultBlockParameter.valueOf(this.lastBlockNumber.add(BigInteger.ONE)), true).send();
+                    EthBlock currentBlock = web3j
+                            .ethGetBlockByNumber(DefaultBlockParameter.valueOf(DefaultBlockParameterName.LATEST.name()), true).send();
+                    BigInteger currentBlockNumber = currentBlock.getBlock().getNumber();
+                    if (this.lastBlockNumber.equals(BigInteger.ZERO) || currentBlockNumber.compareTo(this.lastBlockNumber) > 0) {
                         this.lastBlockNumber = currentBlockNumber;
                         blockEventHandler.newElement(currentBlock);
                     }


### PR DESCRIPTION
Here I've changed the way of checking for a 'new' blocks, using the 'latest' keyword. So we're sure that the number and the object of block we're asking is the same and already included.

Note: this change will cause higher network pressure, I've increased the polling interval to 1000 on my end