### PR TITLE
Web3 calls with normalized addresses

### DIFF
--- a/src/main/java/org/adridadou/ethereum/propeller/rpc/Web3JFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/rpc/Web3JFacade.java
@@ -49,11 +49,11 @@ public class Web3JFacade {
     EthData constantCall(final EthAccount account, final EthAddress address, final EthData data) {
         try {
             return EthData.of(handleError(web3j.ethCall(new Transaction(
-                    account.getAddress().withLeading0x(),
+                    account.getAddress().normalizedWithLeading0x(),
                     null,
                     null,
                     null,
-                    address.withLeading0x(),
+                    address.normalizedWithLeading0x(),
                     BigInteger.ZERO,
                     data.toString()
             ), DefaultBlockParameterName.LATEST).send()));


### PR DESCRIPTION
Go-Ethereum requires addresses to be exact 40 characters long. When an address starts with zeros in Propeller, the trailing zeros are trimmed away, so a normalized version of this address has to be returned.