### PR TITLE
Retrieve missed blocks when polling

### DIFF
--- a/src/main/java/org/adridadou/ethereum/propeller/rpc/Web3JFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/rpc/Web3JFacade.java
@@ -90,6 +90,7 @@ public class Web3JFacade {
                     //In case the block number of the current block is more than 1 higher than the last block, retrieve intermediate blocks
                     for (BigInteger i = this.lastBlockNumber.add(BigInteger.ONE); i.compareTo(currentBlockNumber) < 0; i = i.add(BigInteger.ONE)) {
                         EthBlock missedBlock = web3j.ethGetBlockByNumber(DefaultBlockParameter.valueOf(i), true).send();
+                        this.lastBlockNumber = i;
                         blockEventHandler.newElement(missedBlock);
                     }
 

--- a/src/main/java/org/adridadou/ethereum/propeller/rpc/Web3JFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/rpc/Web3JFacade.java
@@ -82,6 +82,13 @@ public class Web3JFacade {
                             .ethGetBlockByNumber(DefaultBlockParameter.valueOf(DefaultBlockParameterName.LATEST.name()), true).send();
                     BigInteger currentBlockNumber = currentBlock.getBlock().getNumber();
                     if (this.lastBlockNumber.equals(BigInteger.ZERO) || currentBlockNumber.compareTo(this.lastBlockNumber) > 0) {
+                        if (currentBlockNumber.subtract(this.lastBlockNumber).compareTo(BigInteger.ONE) > 0 && !this.lastBlockNumber.equals(BigInteger.ZERO)) {
+                            for (BigInteger i = this.lastBlockNumber; i.compareTo(currentBlockNumber) < 0; i = i.add(BigInteger.ONE)) {
+                                EthBlock missedBlock = web3j
+                                        .ethGetBlockByNumber(DefaultBlockParameter.valueOf(i), true).send();
+                                blockEventHandler.newElement(missedBlock);
+                            }
+                        }
                         this.lastBlockNumber = currentBlockNumber;
                         blockEventHandler.newElement(currentBlock);
                     }


### PR DESCRIPTION
This code retrieves intermediate blocks when the received blocknumber difference with the last block is bigger than 1. Would make it possible/safe to increase the polling interval.