### PR TITLE
Specify log call range

### DIFF
--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumBackend.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumBackend.java
@@ -5,6 +5,7 @@ import org.adridadou.ethereum.propeller.event.EthereumEventHandler;
 import org.adridadou.ethereum.propeller.solidity.SolidityEvent;
 import org.adridadou.ethereum.propeller.values.*;
 import org.web3j.abi.datatypes.Event;
+import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.methods.response.Log;
 
 import java.util.List;
@@ -38,7 +39,7 @@ public interface EthereumBackend {
 
     EthData constantCall(EthAccount account, EthAddress address, EthValue value, EthData data);
 
-    List<EventData> logCall(final SolidityEvent eventDefinition, EthAddress address, final String... optionalTopics);
+    List<EventData> logCall(final DefaultBlockParameter fromBlock, final DefaultBlockParameter toBlock, final SolidityEvent eventDefinition, EthAddress address, final String... optionalTopics);
 
     void register(EthereumEventHandler eventHandler);
 

--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
@@ -488,17 +488,6 @@ public class EthereumFacade {
     }
 
     /**
-     * Returns all the events that happened at a smart contract matching an event signature and indexed parameters
-     *
-     * @param eventDefiniton Event definition that should be matched
-     * @param address address of the smart contract that emits the events
-     * @param optionalTopics Optional indexed event parameters, passed as 64 character hexidecimal string
-     */
-    public List<EventData> getLogs(SolidityEvent eventDefiniton, EthAddress address, String... optionalTopics) {
-        return getLogs(Optional.of(DefaultBlockParameterName.EARLIEST), Optional.of(DefaultBlockParameterName.LATEST), eventDefiniton, address, optionalTopics);
-    }
-
-    /**
      * Encodes an argument manually. This can be useful when you need to send a value to a bytes or bytes32 input
      * @param arg The argument to encode
      * @param solidityType Which solidity type is the argument represented

--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
@@ -477,11 +477,11 @@ public class EthereumFacade {
     /**
      * Returns all the events that happened at a smart contract matching an event signature and indexed parameters
      *
+     * @param fromBlock From which block to search from for the events
+     * @param toBlock Latest block which should be searched from for the events
      * @param eventDefiniton Event definition that should be matched
      * @param address address of the smart contract that emits the events
      * @param optionalTopics Optional indexed event parameters, passed as 64 character hexidecimal string
-     * @param fromBlock From which block to search from for the events
-     * @param toBlock Latest block which should be searched from for the events
      */
     public List<EventData> getLogs(Optional<DefaultBlockParameter> fromBlock, Optional<DefaultBlockParameter> toBlock, SolidityEvent eventDefiniton, EthAddress address, String... optionalTopics) {
         return ethereumProxy.getLogs(fromBlock.orElse(DefaultBlockParameterName.EARLIEST), toBlock.orElse(DefaultBlockParameterName.LATEST), eventDefiniton, address, optionalTopics);

--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
@@ -14,6 +14,7 @@ import org.adridadou.ethereum.propeller.swarm.SwarmService;
 import org.adridadou.ethereum.propeller.values.*;
 import io.reactivex.Observable;
 import org.web3j.abi.datatypes.Event;
+import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.methods.response.Log;
 
 import java.io.IOException;
@@ -480,8 +481,8 @@ public class EthereumFacade {
      * @param optionalTopics Optional indexed event parameters, passed as 64 character hexidecimal string
      * @return
      */
-    public List<EventData> getLogs(SolidityEvent eventDefiniton, EthAddress address, String... optionalTopics) {
-        return ethereumProxy.getLogs(eventDefiniton, address, optionalTopics);
+    public List<EventData> getLogs(DefaultBlockParameter fromBlock, DefaultBlockParameter toBlock, SolidityEvent eventDefiniton, EthAddress address, String... optionalTopics) {
+        return ethereumProxy.getLogs(fromBlock, toBlock, eventDefiniton, address, optionalTopics);
     }
 
     /**

--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
@@ -15,6 +15,7 @@ import org.adridadou.ethereum.propeller.values.*;
 import io.reactivex.Observable;
 import org.web3j.abi.datatypes.Event;
 import org.web3j.protocol.core.DefaultBlockParameter;
+import org.web3j.protocol.core.DefaultBlockParameterName;
 import org.web3j.protocol.core.methods.response.Log;
 
 import java.io.IOException;
@@ -479,10 +480,22 @@ public class EthereumFacade {
      * @param eventDefiniton Event definition that should be matched
      * @param address address of the smart contract that emits the events
      * @param optionalTopics Optional indexed event parameters, passed as 64 character hexidecimal string
-     * @return
+     * @param fromBlock From which block to search from for the events
+     * @param toBlock Latest block which should be searched from for the events
      */
     public List<EventData> getLogs(DefaultBlockParameter fromBlock, DefaultBlockParameter toBlock, SolidityEvent eventDefiniton, EthAddress address, String... optionalTopics) {
         return ethereumProxy.getLogs(fromBlock, toBlock, eventDefiniton, address, optionalTopics);
+    }
+
+    /**
+     * Returns all the events that happened at a smart contract matching an event signature and indexed parameters
+     *
+     * @param eventDefiniton Event definition that should be matched
+     * @param address address of the smart contract that emits the events
+     * @param optionalTopics Optional indexed event parameters, passed as 64 character hexidecimal string
+     */
+    public List<EventData> getLogs(SolidityEvent eventDefiniton, EthAddress address, String... optionalTopics) {
+        return getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, eventDefiniton, address, optionalTopics);
     }
 
     /**

--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
@@ -483,8 +483,8 @@ public class EthereumFacade {
      * @param fromBlock From which block to search from for the events
      * @param toBlock Latest block which should be searched from for the events
      */
-    public List<EventData> getLogs(DefaultBlockParameter fromBlock, DefaultBlockParameter toBlock, SolidityEvent eventDefiniton, EthAddress address, String... optionalTopics) {
-        return ethereumProxy.getLogs(fromBlock, toBlock, eventDefiniton, address, optionalTopics);
+    public List<EventData> getLogs(Optional<DefaultBlockParameter> fromBlock, Optional<DefaultBlockParameter> toBlock, SolidityEvent eventDefiniton, EthAddress address, String... optionalTopics) {
+        return ethereumProxy.getLogs(fromBlock.orElse(DefaultBlockParameterName.EARLIEST), toBlock.orElse(DefaultBlockParameterName.LATEST), eventDefiniton, address, optionalTopics);
     }
 
     /**
@@ -495,7 +495,7 @@ public class EthereumFacade {
      * @param optionalTopics Optional indexed event parameters, passed as 64 character hexidecimal string
      */
     public List<EventData> getLogs(SolidityEvent eventDefiniton, EthAddress address, String... optionalTopics) {
-        return getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, eventDefiniton, address, optionalTopics);
+        return ethereumProxy.getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, eventDefiniton, address, optionalTopics);
     }
 
     /**

--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
@@ -495,7 +495,7 @@ public class EthereumFacade {
      * @param optionalTopics Optional indexed event parameters, passed as 64 character hexidecimal string
      */
     public List<EventData> getLogs(SolidityEvent eventDefiniton, EthAddress address, String... optionalTopics) {
-        return ethereumProxy.getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, eventDefiniton, address, optionalTopics);
+        return getLogs(Optional.of(DefaultBlockParameterName.EARLIEST), Optional.of(DefaultBlockParameterName.LATEST), eventDefiniton, address, optionalTopics);
     }
 
     /**

--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumProxy.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumProxy.java
@@ -22,6 +22,7 @@ import org.apache.commons.lang.ArrayUtils;
 import org.apache.http.util.Asserts;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.web3j.protocol.core.DefaultBlockParameter;
 
 import java.lang.reflect.InvocationTargetException;
 import java.util.*;
@@ -448,8 +449,8 @@ class EthereumProxy {
         return new ArrayList<>();
     }
 
-    public List<EventData> getLogs(SolidityEvent eventDefiniton, EthAddress address, String... optionalTopics) {
-        return ethereum.logCall(eventDefiniton, address, optionalTopics);
+    public List<EventData> getLogs(DefaultBlockParameter fromBlock, DefaultBlockParameter toBlock, SolidityEvent eventDefiniton, EthAddress address, String... optionalTopics) {
+        return ethereum.logCall(fromBlock, toBlock, eventDefiniton, address, optionalTopics);
     }
 
     public long getCurrentBlockNumber() {

--- a/src/main/java/org/adridadou/ethereum/propeller/rpc/EthereumRpc.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/rpc/EthereumRpc.java
@@ -20,6 +20,7 @@ import org.apache.tuweni.units.ethereum.Gas;
 import org.apache.tuweni.units.ethereum.Wei;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.web3j.protocol.core.DefaultBlockParameter;
 import org.web3j.protocol.core.methods.response.EthBlock;
 import org.web3j.protocol.core.methods.response.Log;
 import org.web3j.protocol.core.methods.response.Transaction;
@@ -119,8 +120,8 @@ public class EthereumRpc implements EthereumBackend {
     }
 
     @Override
-    public List<EventData> logCall(SolidityEvent eventDefinition, EthAddress address, String... optionalTopics) {
-        return web3JFacade.loggingCall(eventDefinition, address, optionalTopics).stream().map(log -> toEventInfo(EthHash.of(log.getTransactionHash()), log)).collect(Collectors.toList());
+    public List<EventData> logCall(DefaultBlockParameter fromBlock, DefaultBlockParameter toBlock, SolidityEvent eventDefinition, EthAddress address, String... optionalTopics) {
+        return web3JFacade.loggingCall(fromBlock, toBlock, eventDefinition, address, optionalTopics).stream().map(log -> toEventInfo(EthHash.of(log.getTransactionHash()), log)).collect(Collectors.toList());
     }
 
     @Override

--- a/src/main/java/org/adridadou/ethereum/propeller/rpc/Web3JFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/rpc/Web3JFacade.java
@@ -58,8 +58,8 @@ public class Web3JFacade {
         }
     }
 
-    List<Log> loggingCall(SolidityEvent eventDefiniton, final EthAddress address, final String... optionalTopics) {
-        EthFilter ethFilter = new EthFilter(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, address.withLeading0x());
+    List<Log> loggingCall(DefaultBlockParameter fromBlock, DefaultBlockParameter toBlock, SolidityEvent eventDefiniton, final EthAddress address, final String... optionalTopics) {
+        EthFilter ethFilter = new EthFilter(fromBlock, toBlock, address.withLeading0x());
 
         ethFilter.addSingleTopic(eventDefiniton.getDescription().signatureLong().withLeading0x());
         ethFilter.addOptionalTopics(optionalTopics);

--- a/src/test/java/org/adridadou/ethereum/propeller/backend/EthereumTest.java
+++ b/src/test/java/org/adridadou/ethereum/propeller/backend/EthereumTest.java
@@ -22,6 +22,7 @@ import org.ethereum.util.blockchain.StandaloneBlockchain;
 import org.ethereum.vm.LogInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.web3j.protocol.core.DefaultBlockParameter;
 
 import java.math.BigInteger;
 import java.util.ArrayList;
@@ -147,7 +148,7 @@ public class EthereumTest implements EthereumBackend {
     }
 
     @Override
-    public List<EventData> logCall(SolidityEvent eventDefinition, EthAddress address, String... optionalTopics) {
+    public List<EventData> logCall(DefaultBlockParameter fromBlock, DefaultBlockParameter toBlock, SolidityEvent eventDefinition, EthAddress address, String... optionalTopics) {
         ArrayList events = new ArrayList();
 
         for (long i = 0; i < this.getCurrentBlockNumber(); i++) {

--- a/src/test/scala/org/adridadou/ethereum/propeller/EventsTest.scala
+++ b/src/test/scala/org/adridadou/ethereum/propeller/EventsTest.scala
@@ -12,6 +12,7 @@ import org.adridadou.ethereum.propeller.values.EthValue.ether
 import org.adridadou.ethereum.propeller.values._
 import org.scalatest.check.Checkers
 import org.scalatest.{FlatSpec, Matchers}
+import org.web3j.protocol.core.{DefaultBlockParameterName}
 
 import scala.compat.java8.OptionConverters._
 
@@ -69,23 +70,23 @@ class EventsTest extends FlatSpec with Matchers with Checkers {
       myContract.createEvent("my event is here and it is much longer than anticipated")
 
       // Test for event without indexed parameters
-      var result = ethereum.getLogs(solidityEvent, address)
+      var result = ethereum.getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, solidityEvent, address)
       result.size() shouldBe 1
 
       // Test when indexed parameters don't matter
-      result = ethereum.getLogs(solidityEvent, address, null, null, null)
+      result = ethereum.getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, solidityEvent, address, null, null, null)
       result.size() shouldBe 1
 
       // Test when indexed parameters do matter and should not match
-      result = ethereum.getLogs(solidityEvent, address, "0x0", null, null)
+      result = ethereum.getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, solidityEvent, address, "0x0", null, null)
       result.size() shouldBe 0
 
       // Test when search on a indexed parameter
-      result = ethereum.getLogs(solidityEvent, address, EthData.of("0000000000000000000000000000000000000000000000000000000398484838").withLeading0x(), null, null)
+      result = ethereum.getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, solidityEvent, address, EthData.of("0000000000000000000000000000000000000000000000000000000398484838").withLeading0x(), null, null)
       result.size() shouldBe 1
 
       // Test when search with multiple indexed parameters
-      result = ethereum.getLogs(solidityEvent, address, EthData.of("0000000000000000000000000000000000000000000000000000000398484838").withLeading0x(), null, EthData.of(Crypto.sha3("my event is here and it is much longer than anticipated".getBytes())).withLeading0x())
+      result = ethereum.getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, solidityEvent, address, EthData.of("0000000000000000000000000000000000000000000000000000000398484838").withLeading0x(), null, EthData.of(Crypto.sha3("my event is here and it is much longer than anticipated".getBytes())).withLeading0x())
       result.size() shouldBe 1
     }).asJava.orElseThrow(() => new EthereumApiException("something went wrong!"))
   }

--- a/src/test/scala/org/adridadou/ethereum/propeller/EventsTest.scala
+++ b/src/test/scala/org/adridadou/ethereum/propeller/EventsTest.scala
@@ -71,23 +71,23 @@ class EventsTest extends FlatSpec with Matchers with Checkers {
       myContract.createEvent("my event is here and it is much longer than anticipated")
 
       // Test for event without indexed parameters
-      var result = ethereum.getLogs(solidityEvent, address)
+      var result = ethereum.getLogs(Optional.empty(), Optional.empty(), solidityEvent, address)
       result.size() shouldBe 1
 
       // Test when indexed parameters don't matter
-      result = ethereum.getLogs(solidityEvent, address, null, null, null)
+      result = ethereum.getLogs(Optional.empty(), Optional.empty(), solidityEvent, address, null, null, null)
       result.size() shouldBe 1
 
       // Test when indexed parameters do matter and should not match
-      result = ethereum.getLogs(solidityEvent, address, "0x0", null, null)
+      result = ethereum.getLogs(Optional.empty(), Optional.empty(), solidityEvent, address, "0x0", null, null)
       result.size() shouldBe 0
 
       // Test when search on a indexed parameter
-      result = ethereum.getLogs(solidityEvent, address, EthData.of("0000000000000000000000000000000000000000000000000000000398484838").withLeading0x(), null, null)
+      result = ethereum.getLogs(Optional.empty(), Optional.empty(), solidityEvent, address, EthData.of("0000000000000000000000000000000000000000000000000000000398484838").withLeading0x(), null, null)
       result.size() shouldBe 1
 
       // Test when search with multiple indexed parameters
-      result = ethereum.getLogs(solidityEvent, address, EthData.of("0000000000000000000000000000000000000000000000000000000398484838").withLeading0x(), null, EthData.of(Crypto.sha3("my event is here and it is much longer than anticipated".getBytes())).withLeading0x())
+      result = ethereum.getLogs(Optional.empty(), Optional.empty(), solidityEvent, address, EthData.of("0000000000000000000000000000000000000000000000000000000398484838").withLeading0x(), null, EthData.of(Crypto.sha3("my event is here and it is much longer than anticipated".getBytes())).withLeading0x())
       result.size() shouldBe 1
     }).asJava.orElseThrow(() => new EthereumApiException("something went wrong!"))
   }

--- a/src/test/scala/org/adridadou/ethereum/propeller/EventsTest.scala
+++ b/src/test/scala/org/adridadou/ethereum/propeller/EventsTest.scala
@@ -1,6 +1,7 @@
 package org.adridadou.ethereum.propeller
 
 import java.io.File
+import java.util.Optional
 import java.util.concurrent.CompletableFuture
 
 import com.google.common.collect.Lists
@@ -12,7 +13,7 @@ import org.adridadou.ethereum.propeller.values.EthValue.ether
 import org.adridadou.ethereum.propeller.values._
 import org.scalatest.check.Checkers
 import org.scalatest.{FlatSpec, Matchers}
-import org.web3j.protocol.core.{DefaultBlockParameterName}
+import org.web3j.protocol.core.DefaultBlockParameterName
 
 import scala.compat.java8.OptionConverters._
 
@@ -70,23 +71,23 @@ class EventsTest extends FlatSpec with Matchers with Checkers {
       myContract.createEvent("my event is here and it is much longer than anticipated")
 
       // Test for event without indexed parameters
-      var result = ethereum.getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, solidityEvent, address)
+      var result = ethereum.getLogs(solidityEvent, address)
       result.size() shouldBe 1
 
       // Test when indexed parameters don't matter
-      result = ethereum.getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, solidityEvent, address, null, null, null)
+      result = ethereum.getLogs(solidityEvent, address, null, null, null)
       result.size() shouldBe 1
 
       // Test when indexed parameters do matter and should not match
-      result = ethereum.getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, solidityEvent, address, "0x0", null, null)
+      result = ethereum.getLogs(solidityEvent, address, "0x0", null, null)
       result.size() shouldBe 0
 
       // Test when search on a indexed parameter
-      result = ethereum.getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, solidityEvent, address, EthData.of("0000000000000000000000000000000000000000000000000000000398484838").withLeading0x(), null, null)
+      result = ethereum.getLogs(solidityEvent, address, EthData.of("0000000000000000000000000000000000000000000000000000000398484838").withLeading0x(), null, null)
       result.size() shouldBe 1
 
       // Test when search with multiple indexed parameters
-      result = ethereum.getLogs(DefaultBlockParameterName.EARLIEST, DefaultBlockParameterName.LATEST, solidityEvent, address, EthData.of("0000000000000000000000000000000000000000000000000000000398484838").withLeading0x(), null, EthData.of(Crypto.sha3("my event is here and it is much longer than anticipated".getBytes())).withLeading0x())
+      result = ethereum.getLogs(solidityEvent, address, EthData.of("0000000000000000000000000000000000000000000000000000000398484838").withLeading0x(), null, EthData.of(Crypto.sha3("my event is here and it is much longer than anticipated".getBytes())).withLeading0x())
       result.size() shouldBe 1
     }).asJava.orElseThrow(() => new EthereumApiException("something went wrong!"))
   }


### PR DESCRIPTION
It decreases response times for logging calls by A LOT  (from ~1.5secs to ~300ms for us) if one is able to specify a block range where the events can be found and narrow it down in advance. This PR enables people to specify such a range.