### PR TITLE
repair circleci config to run tests

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,9 +1,44 @@
-machine:
-    java:
-        version: oraclejdk8
+# Java Maven CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-java/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      # specify the version you desire here
+      - image: circleci/openjdk:8-jdk
 
-dependencies:
-  pre:
-    - sudo add-apt-repository ppa:ethereum/ethereum -y; true
-    - sudo apt-get update -y
-    - sudo apt-get install solc -y
+      # Specify service dependencies here if necessary
+      # CircleCI maintains a library of pre-built images
+      # documented at https://circleci.com/docs/2.0/circleci-images/
+      # - image: circleci/postgres:9.4
+
+    working_directory: ~/repo
+
+    environment:
+      # Customize the JVM maximum heap limit
+      MAVEN_OPTS: -Xmx3200m
+
+    steps:
+      - run: sudo wget https://github.com/ethereum/solidity/releases/download/v0.5.9/solc-static-linux -O /usr/local/bin/solc
+      - run: sudo chmod +x /usr/local/bin/solc
+
+      - checkout
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v2-dependencies-{{ checksum "pom.xml" }}
+            # fallback to using the latest cache if no exact match is found
+            - v2-dependencies-
+
+      - run: mvn dependency:go-offline
+
+      - save_cache:
+          paths:
+            - ~/.m2
+          key: v2-dependencies-{{ checksum "pom.xml" }}
+
+      # run tests!
+      - run: mvn test


### PR DESCRIPTION
This was broken due to bit-rot over time and hadn't been running in quite a while.

This version caches *most* of the downloads, there are some that go-offline doesn't get because it's buggy, but I think the extra 15-20 seconds is better than moving the save-cache phase to after the tests. (And neither would address the issue of having all the download output mixed in with what is supposedly the test step.)

But tests run now!