### PR TITLE
Flexibility on the calculated gas price is added

### DIFF
--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumConfig.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumConfig.java
@@ -1,5 +1,7 @@
 package org.adridadou.ethereum.propeller;
 
+import org.adridadou.ethereum.propeller.values.GasPrice;
+
 /**
  * Created by davidroon on 25.04.17.
  * This code is released under Apache 2 license
@@ -7,10 +9,12 @@ package org.adridadou.ethereum.propeller;
 public class EthereumConfig {
     private final String swarmUrl;
     private final long blockWaitLimit;
+    private final GasPrice gasPrice;
 
-    public EthereumConfig(String swarmUrl, long blockWaitLimit) {
+    public EthereumConfig(String swarmUrl, long blockWaitLimit, GasPrice gasPrice) {
         this.swarmUrl = swarmUrl;
         this.blockWaitLimit = blockWaitLimit;
+        this.gasPrice = gasPrice;
     }
 
     public static Builder builder() {
@@ -25,9 +29,14 @@ public class EthereumConfig {
         return blockWaitLimit;
     }
 
+    public GasPrice getGasPrice() {
+        return gasPrice;
+    }
+
     public static class Builder {
         protected String swarmUrl = "http://swarm-gateways.net";
         protected long blockWaitLimit = 16;
+        protected GasPrice gasPrice;
 
 
         public Builder swarmUrl(String url) {
@@ -40,8 +49,14 @@ public class EthereumConfig {
             return this;
         }
 
-        public EthereumConfig build() {
-            return new EthereumConfig(swarmUrl, blockWaitLimit);
+        public Builder fixedGasPrice(GasPrice gasPrice) {
+            this.gasPrice = gasPrice;
+            return this;
         }
+
+        public EthereumConfig build() {
+            return new EthereumConfig(swarmUrl, blockWaitLimit, gasPrice);
+        }
+
     }
 }

--- a/src/main/java/org/adridadou/ethereum/propeller/rpc/EthereumRpc.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/rpc/EthereumRpc.java
@@ -11,7 +11,21 @@ import org.adridadou.ethereum.propeller.EthereumBackend;
 import org.adridadou.ethereum.propeller.event.BlockInfo;
 import org.adridadou.ethereum.propeller.event.EthereumEventHandler;
 import org.adridadou.ethereum.propeller.solidity.SolidityEvent;
-import org.adridadou.ethereum.propeller.values.*;
+import org.adridadou.ethereum.propeller.values.ChainId;
+import org.adridadou.ethereum.propeller.values.EthAccount;
+import org.adridadou.ethereum.propeller.values.EthAddress;
+import org.adridadou.ethereum.propeller.values.EthData;
+import org.adridadou.ethereum.propeller.values.EthHash;
+import org.adridadou.ethereum.propeller.values.EthValue;
+import org.adridadou.ethereum.propeller.values.EventData;
+import org.adridadou.ethereum.propeller.values.GasPrice;
+import org.adridadou.ethereum.propeller.values.GasUsage;
+import org.adridadou.ethereum.propeller.values.Nonce;
+import org.adridadou.ethereum.propeller.values.SmartContractByteCode;
+import org.adridadou.ethereum.propeller.values.TransactionInfo;
+import org.adridadou.ethereum.propeller.values.TransactionReceipt;
+import org.adridadou.ethereum.propeller.values.TransactionRequest;
+import org.adridadou.ethereum.propeller.values.TransactionStatus;
 import org.apache.tuweni.bytes.Bytes;
 import org.apache.tuweni.crypto.SECP256K1;
 import org.apache.tuweni.eth.Address;
@@ -35,16 +49,18 @@ public class EthereumRpc implements EthereumBackend {
     private final Web3JFacade web3JFacade;
     private final EthereumRpcEventGenerator ethereumRpcEventGenerator;
     private final ChainId chainId;
+    private final Optional<GasPrice> fixedGasPrice;
 
     public EthereumRpc(Web3JFacade web3JFacade, ChainId chainId, EthereumRpcConfig config) {
         this.web3JFacade = web3JFacade;
         this.ethereumRpcEventGenerator = new EthereumRpcEventGenerator(web3JFacade, config, this);
+        this.fixedGasPrice = Optional.ofNullable(config.getGasPrice());
         this.chainId = chainId;
     }
 
     @Override
     public GasPrice getGasPrice() {
-        return web3JFacade.getGasPrice();
+        return fixedGasPrice.orElse(web3JFacade.getGasPrice());
     }
 
     @Override

--- a/src/main/java/org/adridadou/ethereum/propeller/rpc/EthereumRpcConfig.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/rpc/EthereumRpcConfig.java
@@ -1,8 +1,9 @@
 package org.adridadou.ethereum.propeller.rpc;
 
-import org.adridadou.ethereum.propeller.EthereumConfig;
-
 import java.util.concurrent.TimeUnit;
+
+import org.adridadou.ethereum.propeller.EthereumConfig;
+import org.adridadou.ethereum.propeller.values.GasPrice;
 
 /**
  * Created by davidroon on 25.04.17.
@@ -15,9 +16,9 @@ public final class EthereumRpcConfig extends EthereumConfig {
     private final String userName;
     private final String password;
 
-
-    private EthereumRpcConfig(boolean pollBlocks, long pollingFrequence, String swarmUrl, long blockWait, AuthenticationType authType, String userName, String password) {
-        super(swarmUrl, blockWait);
+    private EthereumRpcConfig(boolean pollBlocks, long pollingFrequence, String swarmUrl, long blockWait, GasPrice gasPrice,
+            AuthenticationType authType, String userName, String password) {
+        super(swarmUrl, blockWait, gasPrice);
         this.pollBlocks = pollBlocks;
         this.pollingFrequence = pollingFrequence;
         this.authType = authType;
@@ -79,7 +80,7 @@ public final class EthereumRpcConfig extends EthereumConfig {
         }
 
         public EthereumRpcConfig build() {
-            return new EthereumRpcConfig(pollBlocks, pollingFrequence, swarmUrl, blockWaitLimit, authType, userName, password);
+            return new EthereumRpcConfig(pollBlocks, pollingFrequence, swarmUrl, blockWaitLimit, gasPrice, authType, userName, password);
         }
     }
 }


### PR DESCRIPTION
This change fixes the issue with sending tx on POA network: due to the very low gas price required in there (1 Gwei), web3 might (and does) return 0 as median price. From that moment this given account is screwed, as txs will stuck for a long time.

I actually want to add more flexibility on the gas price, to be able to specify it per tx/contract/method, smth like Metamask has - Fast/Slow. This is pretty crucial for Ethereum Mainnet and can save lots of $$$ for tx fees.

Perhaps, smth to consider when implementing #36 ? 