### PR TITLE
Feature/access timestamp

### DIFF
--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
@@ -261,6 +261,17 @@ public class EthereumFacade {
     }
 
     /**
+     * /**
+     * Returns block for provided blocknumber
+     *
+     * @param blockNumber The block number
+     * @return The block if found
+     */
+    public Optional<BlockInfo> getBlock(long blockNumber) {
+        return ethereumProxy.getBlock(blockNumber);
+    }
+
+    /**
      * Sends ether
      * @param fromAccount The account that sends ether
      * @param to The target address

--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
@@ -1,6 +1,7 @@
 package org.adridadou.ethereum.propeller;
 
 import org.adridadou.ethereum.propeller.converters.future.FutureConverter;
+import org.adridadou.ethereum.propeller.event.BlockInfo;
 import org.adridadou.ethereum.propeller.event.EthereumEventHandler;
 import org.adridadou.ethereum.propeller.exception.EthereumApiException;
 import org.adridadou.ethereum.propeller.service.CryptoProvider;

--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumFacade.java
@@ -253,7 +253,6 @@ public class EthereumFacade {
     }
 
     /**
-    /**
      * Returns the current best block number
      * @return The best block number
      */
@@ -262,7 +261,6 @@ public class EthereumFacade {
     }
 
     /**
-     * /**
      * Returns block for provided blocknumber
      *
      * @param blockNumber The block number
@@ -270,6 +268,16 @@ public class EthereumFacade {
      */
     public Optional<BlockInfo> getBlock(long blockNumber) {
         return ethereumProxy.getBlock(blockNumber);
+    }
+
+    /*
+     * Returns block for provided blockhash
+     *
+     * @param blockHash The block number
+     * @return The block if found
+     */
+    public Optional<BlockInfo> getBlock(EthHash blockHash) {
+        return ethereumProxy.getBlock(blockHash);
     }
 
     /**

--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumProxy.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumProxy.java
@@ -346,6 +346,10 @@ class EthereumProxy {
         return ethereum.getBalance(address);
     }
 
+    Optional<BlockInfo> getBlock(long blockNumber) {
+        return this.ethereum.getBlock(blockNumber);
+    }
+
     private void increasePendingTransactionCounter(EthAddress address, EthHash hash) {
         Set<EthHash> hashes = pendingTransactions.computeIfAbsent(address, (key) -> Collections.synchronizedSet(new HashSet<>()));
         hashes.add(hash);

--- a/src/main/java/org/adridadou/ethereum/propeller/EthereumProxy.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/EthereumProxy.java
@@ -350,6 +350,10 @@ class EthereumProxy {
         return this.ethereum.getBlock(blockNumber);
     }
 
+    Optional<BlockInfo> getBlock(EthHash blockHash) {
+        return this.ethereum.getBlock(blockHash);
+    }
+
     private void increasePendingTransactionCounter(EthAddress address, EthHash hash) {
         Set<EthHash> hashes = pendingTransactions.computeIfAbsent(address, (key) -> Collections.synchronizedSet(new HashSet<>()));
         hashes.add(hash);

--- a/src/main/java/org/adridadou/ethereum/propeller/event/BlockInfo.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/event/BlockInfo.java
@@ -2,14 +2,17 @@ package org.adridadou.ethereum.propeller.event;
 
 import org.adridadou.ethereum.propeller.values.TransactionReceipt;
 
+import java.math.BigInteger;
 import java.util.List;
 
 public class BlockInfo {
     public final long blockNumber;
+    public final BigInteger timeStamp;
     public final List<TransactionReceipt> receipts;
 
-    public BlockInfo(long blockNumber, List<TransactionReceipt> receipts) {
+    public BlockInfo(long blockNumber, BigInteger timeStamp, List<TransactionReceipt> receipts) {
         this.blockNumber = blockNumber;
+        this.timeStamp = timeStamp;
         this.receipts = receipts;
     }
 

--- a/src/main/java/org/adridadou/ethereum/propeller/event/BlockInfo.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/event/BlockInfo.java
@@ -7,10 +7,10 @@ import java.util.List;
 
 public class BlockInfo {
     public final long blockNumber;
-    public final BigInteger timestamp;
+    public final long timestamp;
     public final List<TransactionReceipt> receipts;
 
-    public BlockInfo(long blockNumber, BigInteger timestamp, List<TransactionReceipt> receipts) {
+    public BlockInfo(long blockNumber, long timestamp, List<TransactionReceipt> receipts) {
         this.blockNumber = blockNumber;
         this.timestamp = timestamp;
         this.receipts = receipts;

--- a/src/main/java/org/adridadou/ethereum/propeller/event/BlockInfo.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/event/BlockInfo.java
@@ -7,12 +7,12 @@ import java.util.List;
 
 public class BlockInfo {
     public final long blockNumber;
-    public final BigInteger timeStamp;
+    public final BigInteger timestamp;
     public final List<TransactionReceipt> receipts;
 
-    public BlockInfo(long blockNumber, BigInteger timeStamp, List<TransactionReceipt> receipts) {
+    public BlockInfo(long blockNumber, BigInteger timestamp, List<TransactionReceipt> receipts) {
         this.blockNumber = blockNumber;
-        this.timeStamp = timeStamp;
+        this.timestamp = timestamp;
         this.receipts = receipts;
     }
 

--- a/src/main/java/org/adridadou/ethereum/propeller/rpc/EthereumRpc.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/rpc/EthereumRpc.java
@@ -1,5 +1,6 @@
 package org.adridadou.ethereum.propeller.rpc;
 
+import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -166,12 +167,12 @@ public class EthereumRpc implements EthereumBackend {
                 List<TransactionReceipt> receiptList = receipts.entrySet().stream()
                         .map(entry -> toReceipt(txObjects.get(entry.getKey()), entry.getValue())).collect(Collectors.toList());
 
-                return new BlockInfo(block.getNumber().longValue(), receiptList);
+                return new BlockInfo(block.getNumber().longValue(), block.getTimestamp(), receiptList);
             } catch (Throwable ex) {
                 logger.error("error while converting to block info", ex);
-                return new BlockInfo(block.getNumber().longValue(), Collections.emptyList());
+                return new BlockInfo(block.getNumber().longValue(), block.getTimestamp(), Collections.emptyList());
             }
-        }).orElseGet(() -> new BlockInfo(-1, new ArrayList<>()));
+        }).orElseGet(() -> new BlockInfo(-1, BigInteger.ZERO, new ArrayList<>()));
     }
 
     private TransactionReceipt toReceipt(Transaction tx, org.web3j.protocol.core.methods.response.TransactionReceipt receipt) {

--- a/src/main/java/org/adridadou/ethereum/propeller/rpc/EthereumRpc.java
+++ b/src/main/java/org/adridadou/ethereum/propeller/rpc/EthereumRpc.java
@@ -167,12 +167,12 @@ public class EthereumRpc implements EthereumBackend {
                 List<TransactionReceipt> receiptList = receipts.entrySet().stream()
                         .map(entry -> toReceipt(txObjects.get(entry.getKey()), entry.getValue())).collect(Collectors.toList());
 
-                return new BlockInfo(block.getNumber().longValue(), block.getTimestamp(), receiptList);
+                return new BlockInfo(block.getNumber().longValue(), block.getTimestamp().longValue(), receiptList);
             } catch (Throwable ex) {
                 logger.error("error while converting to block info", ex);
-                return new BlockInfo(block.getNumber().longValue(), block.getTimestamp(), Collections.emptyList());
+                return new BlockInfo(block.getNumber().longValue(), block.getTimestamp().longValue(), Collections.emptyList());
             }
-        }).orElseGet(() -> new BlockInfo(-1, BigInteger.ZERO, new ArrayList<>()));
+        }).orElseGet(() -> new BlockInfo(-1, 0, new ArrayList<>()));
     }
 
     private TransactionReceipt toReceipt(Transaction tx, org.web3j.protocol.core.methods.response.TransactionReceipt receipt) {

--- a/src/test/java/org/adridadou/ethereum/propeller/backend/EthJEventListener.java
+++ b/src/test/java/org/adridadou/ethereum/propeller/backend/EthJEventListener.java
@@ -56,7 +56,7 @@ public class EthJEventListener extends EthereumListenerAdapter {
     @Override
     public void onBlock(Block block, List<TransactionReceipt> receipts) {
         EthHash blockHash = EthHash.of(block.getHash());
-        eventHandler.onBlock(new BlockInfo(block.getNumber(), BigInteger.valueOf(block.getTimestamp()), receipts.stream()
+        eventHandler.onBlock(new BlockInfo(block.getNumber(), block.getTimestamp(), receipts.stream()
                 .map(tx -> EthJEventListener.toReceipt(tx, blockHash))
                 .collect(Collectors.toList())));
 

--- a/src/test/java/org/adridadou/ethereum/propeller/backend/EthJEventListener.java
+++ b/src/test/java/org/adridadou/ethereum/propeller/backend/EthJEventListener.java
@@ -56,7 +56,7 @@ public class EthJEventListener extends EthereumListenerAdapter {
     @Override
     public void onBlock(Block block, List<TransactionReceipt> receipts) {
         EthHash blockHash = EthHash.of(block.getHash());
-        eventHandler.onBlock(new BlockInfo(block.getNumber(), receipts.stream()
+        eventHandler.onBlock(new BlockInfo(block.getNumber(), BigInteger.valueOf(block.getTimestamp()), receipts.stream()
                 .map(tx -> EthJEventListener.toReceipt(tx, blockHash))
                 .collect(Collectors.toList())));
 

--- a/src/test/java/org/adridadou/ethereum/propeller/backend/EthereumTest.java
+++ b/src/test/java/org/adridadou/ethereum/propeller/backend/EthereumTest.java
@@ -215,7 +215,7 @@ public class EthereumTest implements EthereumBackend {
     }
 
     BlockInfo toBlockInfo(Block block) {
-        return new BlockInfo(block.getNumber(), BigInteger.valueOf(block.getTimestamp()), block.getTransactionsList().stream()
+        return new BlockInfo(block.getNumber(), block.getTimestamp(), block.getTransactionsList().stream()
                 .map(tx -> this.toReceipt(tx, EthHash.of(block.getHash()))).collect(Collectors.toList()));
     }
 

--- a/src/test/java/org/adridadou/ethereum/propeller/backend/EthereumTest.java
+++ b/src/test/java/org/adridadou/ethereum/propeller/backend/EthereumTest.java
@@ -215,7 +215,7 @@ public class EthereumTest implements EthereumBackend {
     }
 
     BlockInfo toBlockInfo(Block block) {
-        return new BlockInfo(block.getNumber(), block.getTransactionsList().stream()
+        return new BlockInfo(block.getNumber(), BigInteger.valueOf(block.getTimestamp()), block.getTransactionsList().stream()
                 .map(tx -> this.toReceipt(tx, EthHash.of(block.getHash()))).collect(Collectors.toList()));
     }
 


### PR DESCRIPTION
Adds functionality to retrieve a block by hash/number. Now it's only possible to retrieve events at a block found by long/hash, but for our project we would like to retrieve the blockinfo of a particular block.

The info that we are interested in is the timestamp of the block. So that's added as well to the BlockInfo object. This should be added to the EthereumTest and EthJEventListener in propeller-ethj too which I already have ready, but the propeller-core dependency needs to be updated first